### PR TITLE
#11 카카오 블로그 api에 강하게 묶인 일부 객체들 추상화

### DIFF
--- a/simple-blog-finder/src/main/java/com/guardjo/simpleblogfinder/config/CommonConfig.java
+++ b/simple-blog-finder/src/main/java/com/guardjo/simpleblogfinder/config/CommonConfig.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
@@ -23,6 +24,7 @@ public class CommonConfig {
     @Value("${KAKAO_REST_API_KEY}")
     private String KAKAO_REST_API_KEY;
     @Bean
+    @Qualifier("kakaoWebClient")
     public WebClient webClient() {
         return WebClient.builder()
                 .defaultHeader(HttpHeaders.AUTHORIZATION, KAKAO_REST_API_HEADER_PREFIX + " " + KAKAO_REST_API_KEY)

--- a/simple-blog-finder/src/main/java/com/guardjo/simpleblogfinder/constant/BlogSearchConstant.java
+++ b/simple-blog-finder/src/main/java/com/guardjo/simpleblogfinder/constant/BlogSearchConstant.java
@@ -1,6 +1,9 @@
 package com.guardjo.simpleblogfinder.constant;
 
 public class BlogSearchConstant {
+    // blog search api vender type
+    public final static String KAKAO_API = "kakao";
+
     // blog search sort type
     public final static String SEARCH_SORT_TYPE_ACCURACY = "accuracy";
     public final static String SEARCH_SORT_TYPE_RECENCY = "recency";

--- a/simple-blog-finder/src/main/java/com/guardjo/simpleblogfinder/controller/BlogSearchController.java
+++ b/simple-blog-finder/src/main/java/com/guardjo/simpleblogfinder/controller/BlogSearchController.java
@@ -1,15 +1,18 @@
 package com.guardjo.simpleblogfinder.controller;
 
 import com.guardjo.simpleblogfinder.constant.BlogSearchConstant;
-import com.guardjo.simpleblogfinder.dto.KakaoBlogSearchRequest;
-import com.guardjo.simpleblogfinder.dto.KakaoBlogSearchResponse;
+import com.guardjo.simpleblogfinder.dto.BlogSearchRequest;
+import com.guardjo.simpleblogfinder.dto.BlogSearchResponse;
+import com.guardjo.simpleblogfinder.dto.kakao.KakaoBlogSearchRequest;
 import com.guardjo.simpleblogfinder.dto.SearchTermDto;
 import com.guardjo.simpleblogfinder.service.BlogSearchService;
 import com.guardjo.simpleblogfinder.service.SearchManagementService;
-import com.guardjo.simpleblogfinder.util.RequestChecker;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
@@ -18,31 +21,34 @@ import java.util.List;
 @Slf4j
 public class BlogSearchController {
     private final BlogSearchService blogSearchService;
-    private final RequestChecker requestChecker;
     private final SearchManagementService searchManagementService;
 
     public BlogSearchController(@Autowired BlogSearchService blogSearchService,
-                                @Autowired RequestChecker requestChecker,
                                 @Autowired SearchManagementService searchManagementService) {
         this.blogSearchService = blogSearchService;
-        this.requestChecker = requestChecker;
         this.searchManagementService = searchManagementService;
     }
 
     @GetMapping(BlogSearchConstant.REQUEST_BLOG_SEARCH_URL)
-    public KakaoBlogSearchResponse searchBlog(@RequestParam String searchValue,
-                                              @RequestParam(defaultValue = "10") int size,
-                                              @RequestParam(defaultValue = BlogSearchConstant.SEARCH_SORT_TYPE_ACCURACY) String sort,
-                                              @RequestParam(defaultValue = "1") int page) throws Exception{
+    public BlogSearchResponse searchBlog(@RequestParam(defaultValue = BlogSearchConstant.KAKAO_API) String searchApiType,
+                                         @RequestParam String searchValue,
+                                         @RequestParam(defaultValue = "10") int size,
+                                         @RequestParam(defaultValue = BlogSearchConstant.SEARCH_SORT_TYPE_ACCURACY) String sort,
+                                         @RequestParam(defaultValue = "1") int page) throws Exception {
         log.info("[Test] Request Search Blogs, searchValue = {}, sortType = {}, pageSize = {}, pageNumber= {}",
                 searchValue, sort, size, page);
 
-        KakaoBlogSearchRequest request = KakaoBlogSearchRequest.of(searchValue, sort, page, size);
-        requestChecker.blogSearchRequestValidate(request);
+        BlogSearchRequest request = null;
+        BlogSearchResponse response = null;
 
-        KakaoBlogSearchResponse response = blogSearchService.searchBlogs(request);
+        // TODO 향후 다른 블로그 검색 API 호출 기능 추가 시 관련 작업 추가 (default = KAKAO)
+        switch (searchApiType) {
+            default:
+                request = KakaoBlogSearchRequest.of(searchValue, sort, page, size);
+                response = blogSearchService.searchBlogs((KakaoBlogSearchRequest) request);
+        }
 
-        SearchTermDto searchTermDto = searchManagementService.findSearchTerm(request.getQuery());
+        SearchTermDto searchTermDto = searchManagementService.findSearchTerm(searchValue);
         log.debug("[Test] Searched! searchTermDto = {}", searchTermDto.toString());
 
         return response;
@@ -54,5 +60,4 @@ public class BlogSearchController {
 
         return searchManagementService.findSearchTermRanking();
     }
-
 }

--- a/simple-blog-finder/src/main/java/com/guardjo/simpleblogfinder/controller/BlogSearchExceptionHandler.java
+++ b/simple-blog-finder/src/main/java/com/guardjo/simpleblogfinder/controller/BlogSearchExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.guardjo.simpleblogfinder.controller;
 
 import com.guardjo.simpleblogfinder.exception.KakaoRequestException;
+import com.guardjo.simpleblogfinder.exception.SearchRequestException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -9,8 +10,8 @@ import java.util.Optional;
 
 @ControllerAdvice(basePackageClasses = BlogSearchController.class)
 public class BlogSearchExceptionHandler {
-    @ExceptionHandler(KakaoRequestException.class)
-    public ResponseEntity<String> handleBlogSearchRequest(KakaoRequestException exception) {
+    @ExceptionHandler(SearchRequestException.class)
+    public ResponseEntity<String> handleBlogSearchRequest(SearchRequestException exception) {
         return ResponseEntity.badRequest().body(exception.getMessage());
     }
 }

--- a/simple-blog-finder/src/main/java/com/guardjo/simpleblogfinder/dto/BlogSearchRequest.java
+++ b/simple-blog-finder/src/main/java/com/guardjo/simpleblogfinder/dto/BlogSearchRequest.java
@@ -1,0 +1,4 @@
+package com.guardjo.simpleblogfinder.dto;
+
+public abstract class BlogSearchRequest {
+}

--- a/simple-blog-finder/src/main/java/com/guardjo/simpleblogfinder/dto/BlogSearchResponse.java
+++ b/simple-blog-finder/src/main/java/com/guardjo/simpleblogfinder/dto/BlogSearchResponse.java
@@ -1,0 +1,4 @@
+package com.guardjo.simpleblogfinder.dto;
+
+public abstract class BlogSearchResponse {
+}

--- a/simple-blog-finder/src/main/java/com/guardjo/simpleblogfinder/dto/kakao/KakaoBlogDocument.java
+++ b/simple-blog-finder/src/main/java/com/guardjo/simpleblogfinder/dto/kakao/KakaoBlogDocument.java
@@ -1,4 +1,4 @@
-package com.guardjo.simpleblogfinder.dto;
+package com.guardjo.simpleblogfinder.dto.kakao;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/simple-blog-finder/src/main/java/com/guardjo/simpleblogfinder/dto/kakao/KakaoBlogMetaData.java
+++ b/simple-blog-finder/src/main/java/com/guardjo/simpleblogfinder/dto/kakao/KakaoBlogMetaData.java
@@ -1,4 +1,4 @@
-package com.guardjo.simpleblogfinder.dto;
+package com.guardjo.simpleblogfinder.dto.kakao;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;

--- a/simple-blog-finder/src/main/java/com/guardjo/simpleblogfinder/dto/kakao/KakaoBlogSearchRequest.java
+++ b/simple-blog-finder/src/main/java/com/guardjo/simpleblogfinder/dto/kakao/KakaoBlogSearchRequest.java
@@ -1,12 +1,13 @@
-package com.guardjo.simpleblogfinder.dto;
+package com.guardjo.simpleblogfinder.dto.kakao;
 
+import com.guardjo.simpleblogfinder.dto.BlogSearchRequest;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor(staticName = "of")
-public class KakaoBlogSearchRequest {
+public class KakaoBlogSearchRequest extends BlogSearchRequest {
     private String query;
     private String sort;
     private int page;

--- a/simple-blog-finder/src/main/java/com/guardjo/simpleblogfinder/dto/kakao/KakaoBlogSearchResponse.java
+++ b/simple-blog-finder/src/main/java/com/guardjo/simpleblogfinder/dto/kakao/KakaoBlogSearchResponse.java
@@ -1,7 +1,7 @@
-package com.guardjo.simpleblogfinder.dto;
+package com.guardjo.simpleblogfinder.dto.kakao;
 
+import com.guardjo.simpleblogfinder.dto.BlogSearchResponse;
 import lombok.AllArgsConstructor;
-import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,7 +11,7 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class KakaoBlogSearchResponse {
+public class KakaoBlogSearchResponse extends BlogSearchResponse {
     private KakaoBlogMetaData meta;
     private List<KakaoBlogDocument> documents = new ArrayList<>();
 }

--- a/simple-blog-finder/src/main/java/com/guardjo/simpleblogfinder/exception/KakaoRequestException.java
+++ b/simple-blog-finder/src/main/java/com/guardjo/simpleblogfinder/exception/KakaoRequestException.java
@@ -1,6 +1,6 @@
 package com.guardjo.simpleblogfinder.exception;
 
-public class KakaoRequestException extends IllegalArgumentException{
+public class KakaoRequestException extends SearchRequestException{
     public KakaoRequestException(String msg) {
         super(msg);
     }

--- a/simple-blog-finder/src/main/java/com/guardjo/simpleblogfinder/exception/SearchRequestException.java
+++ b/simple-blog-finder/src/main/java/com/guardjo/simpleblogfinder/exception/SearchRequestException.java
@@ -1,0 +1,7 @@
+package com.guardjo.simpleblogfinder.exception;
+
+public abstract class SearchRequestException extends IllegalArgumentException{
+    public SearchRequestException(String s) {
+        super(s);
+    }
+}

--- a/simple-blog-finder/src/main/java/com/guardjo/simpleblogfinder/service/BlogSearchService.java
+++ b/simple-blog-finder/src/main/java/com/guardjo/simpleblogfinder/service/BlogSearchService.java
@@ -1,41 +1,31 @@
 package com.guardjo.simpleblogfinder.service;
 
 import com.guardjo.simpleblogfinder.constant.BlogSearchConstant;
-import com.guardjo.simpleblogfinder.dto.KakaoBlogSearchRequest;
-import com.guardjo.simpleblogfinder.dto.KakaoBlogSearchResponse;
-import com.guardjo.simpleblogfinder.dto.SearchTermDto;
-import com.guardjo.simpleblogfinder.repository.SearchTermRepository;
+import com.guardjo.simpleblogfinder.dto.kakao.KakaoBlogSearchRequest;
+import com.guardjo.simpleblogfinder.dto.kakao.KakaoBlogSearchResponse;
+import com.guardjo.simpleblogfinder.util.kakaoBlogSearchRequestChecker;
 import io.netty.util.CharsetUtil;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.util.UriBuilder;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 @Service
 @Slf4j
 public class BlogSearchService {
-    private final WebClient webClient;
-    private final SearchTermRepository searchTermRepository;
+    private final WebClient kakaoWebClient;
+    private final kakaoBlogSearchRequestChecker kakaoBlogSearchRequestChecker;
 
-    public BlogSearchService(WebClient webClient, SearchTermRepository searchTermRepository) {
-        this.webClient = webClient;
-        this.searchTermRepository = searchTermRepository;
+    public BlogSearchService(WebClient kakaoWebClient, kakaoBlogSearchRequestChecker kakaoBlogSearchRequestChecker) {
+        this.kakaoWebClient = kakaoWebClient;
+        this.kakaoBlogSearchRequestChecker = kakaoBlogSearchRequestChecker;
     }
 
     public KakaoBlogSearchResponse searchBlogs(KakaoBlogSearchRequest request) {
+        kakaoBlogSearchRequestChecker.blogSearchRequestValidate(request);
+
         log.info("[Test] Blog Searching... query = {}", request.getQuery());
         URI uri = UriComponentsBuilder
                 .fromUriString(BlogSearchConstant.KAKAO_BLOG_SEARCH_API_URL)
@@ -47,7 +37,7 @@ public class BlogSearchService {
                 .build()
                 .toUri();
 
-        KakaoBlogSearchResponse response = webClient.get()
+        KakaoBlogSearchResponse response = kakaoWebClient.get()
                 .uri(uri)
                 .retrieve()
                 .bodyToMono(KakaoBlogSearchResponse.class)

--- a/simple-blog-finder/src/main/java/com/guardjo/simpleblogfinder/util/kakaoBlogSearchRequestChecker.java
+++ b/simple-blog-finder/src/main/java/com/guardjo/simpleblogfinder/util/kakaoBlogSearchRequestChecker.java
@@ -1,14 +1,14 @@
 package com.guardjo.simpleblogfinder.util;
 
 import com.guardjo.simpleblogfinder.constant.BlogSearchConstant;
-import com.guardjo.simpleblogfinder.dto.KakaoBlogSearchRequest;
+import com.guardjo.simpleblogfinder.dto.kakao.KakaoBlogSearchRequest;
 import com.guardjo.simpleblogfinder.exception.KakaoRequestException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
-public class RequestChecker {
+public class kakaoBlogSearchRequestChecker {
     private final static int MAX_COUNT = 50;
     private final static int MIN_COUNT = 1;
 

--- a/simple-blog-finder/src/test/java/com/guardjo/simpleblogfinder/controller/BlogSearchControllerTest.java
+++ b/simple-blog-finder/src/test/java/com/guardjo/simpleblogfinder/controller/BlogSearchControllerTest.java
@@ -3,13 +3,13 @@ package com.guardjo.simpleblogfinder.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.guardjo.simpleblogfinder.config.TestConfig;
 import com.guardjo.simpleblogfinder.constant.BlogSearchConstant;
-import com.guardjo.simpleblogfinder.dto.KakaoBlogSearchRequest;
-import com.guardjo.simpleblogfinder.dto.KakaoBlogSearchResponse;
+import com.guardjo.simpleblogfinder.dto.kakao.KakaoBlogSearchRequest;
+import com.guardjo.simpleblogfinder.dto.kakao.KakaoBlogSearchResponse;
 import com.guardjo.simpleblogfinder.dto.SearchTermDto;
 import com.guardjo.simpleblogfinder.exception.KakaoRequestException;
 import com.guardjo.simpleblogfinder.service.BlogSearchService;
 import com.guardjo.simpleblogfinder.service.SearchManagementService;
-import com.guardjo.simpleblogfinder.util.RequestChecker;
+import com.guardjo.simpleblogfinder.util.kakaoBlogSearchRequestChecker;
 import com.guardjo.simpleblogfinder.util.TestDataGenerator;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.DisplayName;
@@ -18,14 +18,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
@@ -50,7 +47,7 @@ class BlogSearchControllerTest {
     @MockBean
     private BlogSearchService blogSearchService;
     @MockBean
-    private RequestChecker requestChecker;
+    private kakaoBlogSearchRequestChecker kakaoBlogSearchRequestChecker;
     @MockBean
     private SearchManagementService searchManagementService;
 
@@ -92,12 +89,11 @@ class BlogSearchControllerTest {
         then(blogSearchService).shouldHaveNoInteractions();
     }
 
-    @DisplayName("요청 인자의 범위를 넘어섰을 경우 테스트")
+    @DisplayName("요청 인자의 범위를 넘어섰을 경우 테스트 (카카오)")
     @ParameterizedTest
     @MethodSource("getParameterTestData")
     void testBadRequestSearch(String paramKey, String paramValue) throws Exception {
-        given(blogSearchService.searchBlogs(any(KakaoBlogSearchRequest.class))).willReturn(TEST_RESPONSE);
-        given(requestChecker.blogSearchRequestValidate(any(KakaoBlogSearchRequest.class))).willThrow(KakaoRequestException.class);
+        given(blogSearchService.searchBlogs(any(KakaoBlogSearchRequest.class))).willThrow(new KakaoRequestException("test"));
 
         MultiValueMap params = new LinkedMultiValueMap();
         params.add("searchValue", "test");
@@ -108,7 +104,7 @@ class BlogSearchControllerTest {
                         .queryParams(params))
                 .andExpect(status().isBadRequest());
 
-        then(blogSearchService).shouldHaveNoInteractions();
+        then(blogSearchService).should().searchBlogs(any(KakaoBlogSearchRequest.class));
     }
 
     @DisplayName("정렬 옵션 별 블로그 검색 테스트")

--- a/simple-blog-finder/src/test/java/com/guardjo/simpleblogfinder/service/BlogSearchServiceTest.java
+++ b/simple-blog-finder/src/test/java/com/guardjo/simpleblogfinder/service/BlogSearchServiceTest.java
@@ -1,9 +1,10 @@
 package com.guardjo.simpleblogfinder.service;
 
 import com.guardjo.simpleblogfinder.config.CommonConfig;
-import com.guardjo.simpleblogfinder.dto.KakaoBlogSearchRequest;
-import com.guardjo.simpleblogfinder.dto.KakaoBlogSearchResponse;
+import com.guardjo.simpleblogfinder.dto.kakao.KakaoBlogSearchRequest;
+import com.guardjo.simpleblogfinder.dto.kakao.KakaoBlogSearchResponse;
 import com.guardjo.simpleblogfinder.util.TestDataGenerator;
+import com.guardjo.simpleblogfinder.util.kakaoBlogSearchRequestChecker;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,12 +20,15 @@ import java.net.URI;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 
 @Import(CommonConfig.class)
 @ExtendWith(MockitoExtension.class)
 class BlogSearchServiceTest {
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private WebClient webClient;
+    @Mock
+    private kakaoBlogSearchRequestChecker kakaoBlogSearchRequestChecker;
     @InjectMocks
     private BlogSearchService blogSearchService;
 
@@ -35,6 +39,7 @@ class BlogSearchServiceTest {
     void testSearchBlog() {
         KakaoBlogSearchRequest kakaoBlogSearchRequest = KakaoBlogSearchRequest.of("test", null, 10, 1);
 
+        given(kakaoBlogSearchRequestChecker.blogSearchRequestValidate(any(KakaoBlogSearchRequest.class))).willReturn(true);
         given(webClient.get()
                 .uri(any(URI.class))
                 .retrieve()
@@ -44,5 +49,6 @@ class BlogSearchServiceTest {
         KakaoBlogSearchResponse actualResponse = blogSearchService.searchBlogs(kakaoBlogSearchRequest);
 
         assertThat(actualResponse).isEqualTo(TEST_RESPONSE);
+        then(kakaoBlogSearchRequestChecker).should().blogSearchRequestValidate(any(KakaoBlogSearchRequest.class));
     }
 }

--- a/simple-blog-finder/src/test/java/com/guardjo/simpleblogfinder/util/TestDataGenerator.java
+++ b/simple-blog-finder/src/test/java/com/guardjo/simpleblogfinder/util/TestDataGenerator.java
@@ -1,9 +1,9 @@
 package com.guardjo.simpleblogfinder.util;
 
 import com.guardjo.simpleblogfinder.domain.SearchTerm;
-import com.guardjo.simpleblogfinder.dto.KakaoBlogDocument;
-import com.guardjo.simpleblogfinder.dto.KakaoBlogMetaData;
-import com.guardjo.simpleblogfinder.dto.KakaoBlogSearchResponse;
+import com.guardjo.simpleblogfinder.dto.kakao.KakaoBlogDocument;
+import com.guardjo.simpleblogfinder.dto.kakao.KakaoBlogMetaData;
+import com.guardjo.simpleblogfinder.dto.kakao.KakaoBlogSearchResponse;
 import com.guardjo.simpleblogfinder.dto.SearchTermDto;
 
 import java.time.ZonedDateTime;


### PR DESCRIPTION
- controller 레이어에서 관련 입/출력을 추상객체로 전환 -- 입력값 중 향후 다른 api 서비스 추가를 염두해두어 searchApiType 파라미터 추가 (default = kakao) -- request validation check를 service 레이어로 내림
- 일부 입/출력 DTO 추상화에 따른 상속 작업 구성

- controller, service 레이어 리팩토링에 따른 테스트 코드 수정